### PR TITLE
Add BrainDB to Applications section

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ _A spatial SQLite extension for vector geodata functionality_
 
 - **Corgi VIN Decoder** (github: [cardog-ai/corgi](https://github.com/cardog-ai/corgi)) -- Vehicle identification decoder using heavily optimized SQLite database. Reduced NHTSA's 1.5GB dataset to 21MB with 100x performance improvement.
 - **R-Mem** (github: [Adaimade/R-Mem](https://github.com/Adaimade/R-Mem)) -- Lightweight Rust AI memory system using SQLite for both vector storage (cosine similarity) and graph storage. Reimplements mem0's architecture in ~1,748 lines.
+- **BrainDB** (github: [beckfexx/BrainDB](https://github.com/beckfexx/BrainDB)) -- Local-first AI memory and multi-agent orchestrator using SQLite with FTS5 for hybrid search. 110 REST endpoints, 51 MCP tools, knowledge graph, self-learning. TypeScript/Bun.
 
 ## Misc
 


### PR DESCRIPTION
## Add BrainDB

[BrainDB](https://github.com/beckfexx/BrainDB) — Local-first AI memory and multi-agent orchestrator using SQLite with FTS5 for hybrid search. 110 REST endpoints, 51 MCP tools, knowledge graph, self-learning. TypeScript/Bun.

Added to the Applications section.