### PR TITLE
feat: add KubeStellar Console to Applications section

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ _A spatial SQLite extension for vector geodata functionality_
 - **Corgi VIN Decoder** (github: [cardog-ai/corgi](https://github.com/cardog-ai/corgi)) -- Vehicle identification decoder using heavily optimized SQLite database. Reduced NHTSA's 1.5GB dataset to 21MB with 100x performance improvement.
 - **R-Mem** (github: [Adaimade/R-Mem](https://github.com/Adaimade/R-Mem)) -- Lightweight Rust AI memory system using SQLite for both vector storage (cosine similarity) and graph storage. Reimplements mem0's architecture in ~1,748 lines.
 - **BrainDB** (github: [beckfexx/BrainDB](https://github.com/beckfexx/BrainDB)) -- Local-first AI memory and multi-agent orchestrator using SQLite with FTS5 for hybrid search. 110 REST endpoints, 51 MCP tools, knowledge graph, self-learning. TypeScript/Bun.
+- **KubeStellar Console** (github: [kubestellar/console](https://github.com/kubestellar/console)) -- Multi-cluster Kubernetes dashboard using SQLite WASM in a Web Worker for persistent client-side caching. SWR pattern with IndexedDB fallback, keeping structured query performance off the main thread for real-time observability across edge and cloud clusters. Go/TypeScript.
 
 ## Misc
 


### PR DESCRIPTION
Add [KubeStellar Console](https://github.com/kubestellar/console) to the Applications section.

KubeStellar Console is a multi-cluster Kubernetes dashboard that uses **SQLite WASM** in a **Web Worker** for persistent client-side caching. It implements a stale-while-revalidate (SWR) pattern with IndexedDB fallback, keeping structured query performance off the main thread for a responsive real-time observability experience.

The SQLite WASM layer provides:
- Persistent cache across page reloads (faster than IndexedDB for structured queries)
- Off-main-thread execution via Web Worker
- Fallback to IndexedDB when WASM isn't available

- **Repository:** https://github.com/kubestellar/console
- **Live demo:** [console.kubestellar.io](https://console.kubestellar.io)
- **CNCF project** (Apache 2.0)