### PR TITLE
Add OpenFiles to commercial desktop SQLite tools

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -8,6 +8,7 @@ A collection of awesome commercial  sqlite tools, scripts, etc.
 
 Desktop
 - [1bench](https://1bench.dev/sqlite) — Native cross-platform desktop GUI with first-class SQLite support alongside Postgres, Redis, Elasticsearch, ClickHouse, Qdrant, and more.
+- [OpenFiles](https://openfiles.pansysoft.app/) — Cross-platform desktop file workspace with SQLite schema browsing, editable tables, SQL queries and history, table and index management, and CSV export.
 - [VizSQL](https://www.vizsql.io) — Instant SQLite browser that **automatically generates ER diagrams** via drag-and-drop. Features reverse engineering of schemas, and DDL generation. 100% private and WASM-based.
 - [SQLite Expert](http://www.sqliteexpert.com) - note: free personal edition and commercial "professional" edition
 - [SQLiteSpy](https://www.yunqa.de/delphi/apps/sqlitespy/index)


### PR DESCRIPTION
## What changed

Adds [OpenFiles](https://openfiles.pansysoft.app/) to `COMMERCIAL.md` under SQLite Admin Tools / Desktop.

## Why

OpenFiles is proprietary and includes a desktop SQLite workspace with schema browsing, editable tables, SQL queries and history, table and index management, and CSV export. The commercial page is therefore the appropriate place rather than the open-source list.

## Checks

- `git diff --check`
- Confirmed the entry is only in `COMMERCIAL.md`