### PR TITLE
Add LibreDB Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ and many more
 - **web gui for sqlite** (web: [extendsclass.com](https://extendsclass.com/sqlite-browser.html), github: [hautdefrance/Web-GUI-for-SQLite](https://github.com/hautdefrance/Web-GUI-for-SQLite) by Cyril Bois -- a web-based SQLite database browser written in JavaScript
 - **SQLite Hub** ★4 (web: [sqlite-hub](https://oliverjessner.at/sqlite-hub/), github: [oliverjessner/sqlite-hub](https://github.com/oliverjessner/sqlite-hub)) -- a web-based SQLite database browser written in NodeJS
 - **LiteAdmin** (github: [martijndeb/liteadmin](https://github.com/martijndeb/liteadmin)) -- a web-based SQLite administration tool written in dependency free PHP
+- **LibreDB Studio** ★135 (web: [libredb.org](https://libredb.org), github: [libredb/libredb-studio](https://github.com/libredb/libredb-studio)) -- a web-based SQL IDE written in TypeScript, covering SQLite alongside nine other engines
 
 ### Desktop
 


### PR DESCRIPTION
Adds LibreDB Studio to SQLite Admin Tools / Web.

- Repo: https://github.com/libredb/libredb-studio
- License: MIT
- Install: `docker run -d -p 3000:3000 ghcr.io/libredb/libredb-studio:latest`

A web-based SQL IDE written in TypeScript. SQLite is read through the runtime's built-in driver, `bun:sqlite` under Bun and `node:sqlite` under Node 24 or later, against file-based or in-memory databases. It is not SQLite-only, which is why the entry says so plainly: nine other engines share the same editor, schema explorer and ER diagrams. Remove or reword if the section is meant for single-engine tools.
