### PR TITLE
Add Mongrel

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -12,6 +12,7 @@ Desktop
 - [SQLite Expert](http://www.sqliteexpert.com) - note: free personal edition and commercial "professional" edition
 - [SQLiteSpy](https://www.yunqa.de/delphi/apps/sqlitespy/index)
 - [SQLite Administrator](http://sqliteadmin.orbmu2k.de)
+- [Mongrel](https://www.visorcraft.com/sqlite) — Cross-platform desktop GUI (Windows, macOS, Linux) for SQLite browsing, editing, DDL, EXPLAIN QUERY PLAN, import/export, migrations, and scheduled backups. Proprietary with a 7-day free trial.
 
 
 <!--


### PR DESCRIPTION
Adds [Mongrel](https://www.visorcraft.com/sqlite) to the COMMERCIAL page under SQLite Admin Tools → Desktop, per the README's note that closed source / proprietary tools belong on the COMMERCIAL page.

Mongrel is a proprietary, paid cross-platform desktop app (Windows, macOS, Linux) with a 7-day free trial. Its SQLite support covers browsing, editing, DDL, EXPLAIN QUERY PLAN, import/export, migrations, and scheduled backups.