### PR TITLE
Add DBTool to Desktop admin tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Major
 - **DB Browser for SQLite** ★3,718 (web: [sqlitebrowser.org](http://sqlitebrowser.org), github: [sqlitebrowser/sqlitebrowser](https://github.com/sqlitebrowser/sqlitebrowser)) -- formerly known as SQLite Database Browser
 - [**SQLite Toolbox**](https://visualstudiogallery.msdn.microsoft.com/0e313dfd-be80-4afb-b5e9-6e74d369f7a1) (codeplex: [sqlcetoolbox] (http://sqlcetoolbox.codeplex.com)) -- Visual Studio extension (add-in); coded by Erik Ejlskov Jensen
 - [DataStation](https://github.com/multiprocessio/datastation) - Easily query, script, and visualize data from every database, file, and API.
+- [DBTool](https://github.com/achi777/db-tool) - Free and open-source desktop client for SQLite and five other engines, with a visual query builder, a schema designer and an editable results grid. Linux, Windows, macOS.
 - [SQLTorrent](https://github.com/bittorrent/sqltorrent) - Sqltorrent is a custom VFS for sqlite which allows applications to query an sqlite database contained within a torrent.
 
 


### PR DESCRIPTION
Adds **DBTool** to the SQLite Admin Tools / Desktop section, in the list's existing order.

[DBTool](https://github.com/achi777/db-tool) is a free, open-source (AGPL-3.0) desktop database client with native builds for Windows, macOS and Linux. SQLite files open with no server involved, and the object tree, table designer and editable grid work the same way they do for the other five engines.

It has true server-side pagination (ordering, counting and paging happen in the database rather than in the client), a schema-aware SQL editor, a drag-to-join visual query builder that generates the `SELECT`, a visual table designer with a live DDL preview, and editable ER diagrams. Connection passwords are stored in the OS keychain; there is no telemetry and no account.

I am the author of this project.
