### PR TITLE
Add sqliteproof

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ _A spatial SQLite extension for vector geodata functionality_
 - **litestream** (github: [benbjohnson/litestream](https://github.com/benbjohnson/litestream)) - Streaming replication for SQLite
 - **HA** (github: [litesql/ha](https://github.com/litesql/ha)) - High Available SQLite cluster
 - **silentdrop** (github: [sravan27/silentdrop](https://github.com/sravan27/silentdrop)) -- zero-dep MIT TypeScript correctness checker for JS implementations of SQLite operators (`upper`/`lower` ASCII vs Unicode fold, `length`/`substr` code-points vs UTF-16 code units, integer overflow). Catches the silent-wrong-row class found shipping eight fixes to PowerSync sync-rules and four other JS DBs.
+- **sqliteproof** (github: [OrbitalKeyAi/sqliteproof](https://github.com/OrbitalKeyAi/sqliteproof)) -- zero-dependency MIT integrity checker that reports damage per **table** rather than per page; `PRAGMA integrity_check` answers with page numbers, this answers with which tables are intact, how many rows are unreadable, and where each damaged table breaks. Opens the database read-only.
 
 ## Schema Documentation Generators
 


### PR DESCRIPTION
Adds **sqliteproof** to Misc, beside the other correctness-checking tools.

`PRAGMA integrity_check` is good at *detecting* damage, but it answers with page numbers:

```
Page 4: btreeInitPage() returns error code 11
```

Nobody stores data by page number. sqliteproof answers the questions you actually have when a database goes bad — which tables can I still trust, how many rows did I lose, is anything safe to export:

```
orders      damaged   392/400 rows, 8 lost, breaks after row 182
customers   intact    400/400
audit_log   intact    400/400
```

MIT, zero dependencies, Python 3.9+. It opens the database **read-only** — a tool asked to inspect a damaged file should not be able to damage it further — and reports UNKNOWN rather than "clean" when the damage prevents a determination.

Tested against databases built by SQLite and then corrupted at known page offsets: 3/3 damaged databases localised to the correct table, 0 false alarms, 0 false-clean.

https://github.com/OrbitalKeyAi/sqliteproof · https://pypi.org/project/sqliteproof/