### PR TITLE
Add XYZZY to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ _A spatial SQLite extension for vector geodata functionality_
 - **R-Mem** (github: [Adaimade/R-Mem](https://github.com/Adaimade/R-Mem)) -- Lightweight Rust AI memory system using SQLite for both vector storage (cosine similarity) and graph storage. Reimplements mem0's architecture in ~1,748 lines.
 - **BrainDB** (github: [beckfexx/BrainDB](https://github.com/beckfexx/BrainDB)) -- Local-first AI memory and multi-agent orchestrator using SQLite with FTS5 for hybrid search. 110 REST endpoints, 51 MCP tools, knowledge graph, self-learning. TypeScript/Bun.
 - **KubeStellar Console** (github: [kubestellar/console](https://github.com/kubestellar/console)) -- Multi-cluster Kubernetes dashboard using SQLite WASM in a Web Worker for persistent client-side caching. SWR pattern with IndexedDB fallback, keeping structured query performance off the main thread for real-time observability across edge and cloud clusters. Go/TypeScript.
+- **XYZZY** (github: [Project-Nexus-YR/XYZZY](https://github.com/Project-Nexus-YR/XYZZY)) -- Self-hosted multiplayer AI decision workspace that runs as one Python process on a single SQLite file (aiosqlite): rooms, parallel agent runs, per-output verdicts and a hash-chained event log all live in one database, verified by an audit CLI. Python.
 
 ## Misc
 


### PR DESCRIPTION
One entry at the end of Applications, in the existing bold-name / github / description format. SQLite is the only database: rooms, runs, verdicts and the hash-chained event log live in one file through aiosqlite.

XYZZY is a self-hosted workspace where a small team branches a question into two or three parallel specialist agent runs, a person includes or excludes each output, and the included outputs become a Decision Brief whose claims link to the outputs that produced them. The event log is hash-chained with an audit command, and actions that change the room wait for human approval. One Python process on a single SQLite file, Docker image, works with Ollama, LM Studio or any OpenAI-compatible endpoint. Apache-2.0, 979 tests in CI, tagged v0.4.0.

Repo: https://github.com/Project-Nexus-YR/XYZZY
Live page: https://xyzzy.yasserameur-dev.workers.dev/

I am the author. Placed per the contributing guidelines; happy to adjust wording or section.